### PR TITLE
BugFix: Invalid Marker Name

### DIFF
--- a/src/PlotlyFunctions.ipf
+++ b/src/PlotlyFunctions.ipf
@@ -462,7 +462,8 @@ static Function/T AssignMarkerName(MrkrNum, mFill)
 			PlyMrkr = "diamond"
 			break
 		case 8:
-			PlyMrkr = "dot"
+			PlyMrkr = "circle"
+			mFill = 0
 			break
 		case 9: // hline
 			PlyMrkr = "line-ew"
@@ -500,7 +501,7 @@ static Function/T AssignMarkerName(MrkrNum, mFill)
 			mFill = 1
 			break
 		case 19: // circle
-			PlyMrkr = "dot"
+			PlyMrkr = "circle"
 			mFill = 1
 			break
 		case 20: // slash


### PR DESCRIPTION
The "dot" marker does not exist and yields a plotly error.