### PR TITLE
Use dynamic Duplicate to get 1D traces

### DIFF
--- a/src/PlotlyFunctions.ipf
+++ b/src/PlotlyFunctions.ipf
@@ -1444,29 +1444,21 @@ static Function/T CreateTrObj(traceName, graph)
 	if(!cmpstr(Yrange, ""))
 		Duplicate/FREE Tempyw yw
 	else
-		// @todo support slicing for all possible variations: x-references with () and multiple dimensions.
+		// Use trace range for Duplicate
+		// @todo support quoted wave names
+		Execute ("Duplicate/O/R=" + Yrange + " " + GetWavesDataFolder(Tempyw, 2) + " root:Packages:Plotly:tempyw")
+		WAVE yw = root:Packages:Plotly:tempyw
+
+		// Reduce to one dimension
 		string expr="\[([[:digit:]\*]+)(?:,\s*([[:digit:]\*]+))?\](.*)"
 		string pRangeStart, pRangeStop
 		SplitString/E=(expr) Yrange, pRangeStart, pRangeStop, Yrange
-		if(!cmpstr(pRangeStart, "*") && !cmpstr(pRangeStop, ""))
-			pRangeStop = pRangeStart
-			pRangeStart = "0"
-		endif
-
 		string qRangeStart, qRangeStop
 		SplitString/E=(expr) Yrange, qRangeStart, qRangeStop, Yrange
-		if(!cmpstr(qRangeStart, "*") && !cmpstr(pRangeStop, ""))
-			qRangeStop = qRangeStart
-			qRangeStart = "0"
-		endif
-
-		if(!cmpstr(qRangeStart, "") && !cmpstr(qRangeStop, ""))
-			Duplicate/FREE/R=[str2num(pRangeStart), str2num(pRangeStop)] Tempyw yw
+		if(!cmpstr(qRangeStop, "") && !!cmpstr(qRangeStart, "*"))
 			Redimension/N=(-1, 0) yw
-		else
-			Duplicate/FREE/R=[str2num(pRangeStart)][str2num(qRangeStart), str2num(qRangeStop)] Tempyw yw
+		elseif(!cmpstr(pRangeStop, "") && !!cmpstr(pRangeStop, "*"))
 			Redimension/E=1/N=(DimSize(yw, 1), 0) yw
-			SetScale/P x, DimOffset(Tempyw, 1), DimDelta(Tempyw, 1), yw
 		endif
 	endif
 	variable trLen = DimSize(yw, 0)

--- a/src/PlotlyFunctions.ipf
+++ b/src/PlotlyFunctions.ipf
@@ -3442,9 +3442,16 @@ Function/WAVE DuplicateFromRange(wv, range)
 	string pRangeStart, pRangeStop
 	string qRangeStart, qRangeStop
 	string expr
+	variable rangeTest, rangeStep
 
 	if(!cmpstr(range, ""))
 		return wv
+	endif
+
+	rangeTest = strsearch(range, ":", 0)
+	if(rangeTest != -1)
+		rangeStep = str2num(range[rangeTest + 1, strlen(range) - 2])
+		range = range[0, rangeTest - 1] + "]"
 	endif
 
 	Execute ("Duplicate/O/R=" + range + " " + GetWavesDataFolder(wv, 2) + " root:Packages:Plotly:temp")
@@ -3458,6 +3465,10 @@ Function/WAVE DuplicateFromRange(wv, range)
 		Redimension/N=(-1, 0) temp
 	elseif(!cmpstr(pRangeStop, "") && !!cmpstr(pRangeStop, "*"))
 		Redimension/E=1/N=(DimSize(temp, 1), 0) temp
+	endif
+
+	if(rangeStep > 0)
+		Resample/DOWN=(rangeStep) temp
 	endif
 
 	return temp


### PR DESCRIPTION
Only export the one dimension that is visible as a trace.
Support for ranges with [*] and [*][2].