### PR TITLE
WIP: Fix the axis position

### DIFF
--- a/src/PlotlyFunctions.ipf
+++ b/src/PlotlyFunctions.ipf
@@ -2104,7 +2104,7 @@ static Function/T createAxisObj(axisName, PlyAxisName, graph, Orient, AxisNum)
 			obj += "\"side\":\"top\",\r"
 			RorT = 1
 		endif
-		// Free axis calculations for Horizontal axes-----------------------------------------------------------------------------
+		// Free axis calculations for Horizontal axes
 		if(FreeIndex > -1) // this is a free axis if true
 			if(StringMatch(info[Freeindex , 11], "{")) 	// We have to read a number and an axis name
 				cma = strsearch(info, ",", freeindex + 11)
@@ -2193,7 +2193,14 @@ static Function/T createAxisObj(axisName, PlyAxisName, graph, Orient, AxisNum)
 					obj += "\"position\":" + dub2str(FreeFrac) + ",\r"
 				endif
 			endif
-		endif // Not a free axis, so do nothing
+		else // Not a free axis
+			/// @todo not sure how to force the left axis to line up with the bottom axis it belongs to.
+			if(RorT)
+				obj += "\"position\":1,\r"
+			else
+				obj += "\"position\":0,\r"
+			endif
+		endif
 	endif
 
 	string defaultFnt = GetDefaultFont(graph)


### PR DESCRIPTION
If not explicitly set, axis position of "xaxis" is displayed against
"yaxis". As the axis order is not strictly to have left, right, bottom
or top in the beginning, referencing the main axis, this leads to
wrongly set axes.

Default to plotting the left axis at 0% and the right axis at 100%

This does not respect axes that are drawn at specific percentages.